### PR TITLE
Avoid unnecessary file open in reader.py

### DIFF
--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -229,13 +229,9 @@ class LifImage:
             if (requested_dims[i] + 1) > self.dims_n.get(i, 0):
                 raise ValueError(f"Requested frame in dimension {str(i)} " f"doesn't exist")
 
-        if isinstance(self.filename, (str, bytes, os.PathLike)):
-            image = open(self.filename, "rb")
-        elif isinstance(self.filename, io.IOBase):
-            image = self.filename
-        else:
+        if not isinstance(self.filename, (str, bytes, os.PathLike, io.IOBase)):
             raise TypeError(
-                f"expected str, bytes, os.PathLike, or io.IOBase, " f"not {type(self.filename)}"
+                f"expected str, bytes, os.PathLike, or io.IOBase, not {type(self.filename)}"
             )
 
         bytes_per_pixel = self.bit_depth[0] // 8


### PR DESCRIPTION
This pull request fixes a file-handling issue in `reader.py`. The code previously opened the file outside of a context manager, but that file handle was never used and was later reopened inside a `with` block. This resulted in an unnecessary file open and a potential resource leak. While Python’s garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change removes the redundant `open()` call without changing behavior. The issue was identified during an ongoing research project.